### PR TITLE
Add 1st formal checks of GPIO peripheral

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -1,0 +1,36 @@
+# Test NEORV32 processor with formal verification
+
+name: Processor
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'core/**'
+  pull_request:
+    branches:
+    - main
+    paths:
+    - 'core/**'
+  workflow_dispatch:
+
+jobs:
+
+
+  Core-Container:
+    runs-on: ubuntu-latest
+
+    name: '🛳️ Container | Core'
+
+    steps:
+
+    - name: '🧰 Repository Checkout'
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: '🚧 Run Processor Core Hardware Formal Tests with GHDL and SymbiYosys'
+      uses: docker://ghcr.io/hdl/amd64/formal/all
+      with:
+        args: ./core/test.sh prove

--- a/core/lib/neorv32_bus_protocol.vhd
+++ b/core/lib/neorv32_bus_protocol.vhd
@@ -1,0 +1,130 @@
+-- #################################################################################################
+-- # << NEORV32 - NEORV32 bus protocol PSL model >>                                                #
+-- # ********************************************************************************************* #
+-- # Implements a simple model of the NEORV32 bus protocol using PSL. Use ASSUMES generic to       #
+-- # between assert (verifying behavior) and assume (constraining behavior) directives.            #
+-- # ********************************************************************************************* #
+-- # BSD 3-Clause License                                                                          #
+-- #                                                                                               #
+-- # Copyright (c) 2023, Torsten Meissner. All rights reserved.                                    #
+-- #                                                                                               #
+-- # Redistribution and use in source and binary forms, with or without modification, are          #
+-- # permitted provided that the following conditions are met:                                     #
+-- #                                                                                               #
+-- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+-- #    conditions and the following disclaimer.                                                   #
+-- #                                                                                               #
+-- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+-- #    conditions and the following disclaimer in the documentation and/or other materials        #
+-- #    provided with the distribution.                                                            #
+-- #                                                                                               #
+-- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+-- #    endorse or promote products derived from this software without specific prior written      #
+-- #    permission.                                                                                #
+-- #                                                                                               #
+-- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+-- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+-- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+-- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+-- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+-- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+-- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+-- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+-- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+-- # ********************************************************************************************* #
+-- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- #################################################################################################
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+
+entity neorv32_bus_protocol is
+  generic (
+    ASSUMES : boolean := false
+  );
+  port (
+    clk_i  : in  std_ulogic;
+    rstn_i : in  std_ulogic;
+    addr_i : in  std_ulogic_vector(31 downto 0); -- address
+    rden_i : in  std_ulogic; -- read enable
+    wren_i : in  std_ulogic; -- write enable
+    data_i : in  std_ulogic_vector(31 downto 0); -- data in
+    data_o : in  std_ulogic_vector(31 downto 0); -- data out
+    ack_o  : in  std_ulogic; -- transfer acknowledge
+    err_o  : in  std_ulogic  -- transfer error
+  );
+end entity;
+
+
+architecture formal of neorv32_bus_protocol is
+
+begin
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk_i);
+
+  -- define properties for reuse
+
+  -- Some assumptions about the bus interface
+  -- These assumptions are based on the bus interface specification
+  -- in section '3.12.12. Bus Interface' of the neorv32 documentation.
+
+  -- No read / write request during reset
+  property no_read_write_during_reset is (
+    always (not rstn_i -> not wren_i and not rden_i)
+  );
+
+  -- Read / write requests last one cycle only
+  -- There are no new requests until peripheral responds
+  property no_read_write_until_write_resp is (
+    always (wren_i -> next (not wren_i and not rden_i until_ ack_o or err_o))
+  );
+  property no_read_write_until_read_resp is (
+    always (rden_i -> next (not rden_i and not wren_i until_ ack_o or err_o))
+  );
+  
+  -- Never write and read request at the same time
+  property onehot0_read_write is (
+    never (wren_i and rden_i)
+  );
+
+  -- Signal stability during write bus cycle
+  property addr_stable_until_write_resp is (
+    always (wren_i -> next (stable(addr_i) until_ (ack_o or err_o)))
+  );
+  property data_stable_until_write_resp is (
+    always (wren_i -> next (stable(data_o) until_ (ack_o or err_o)))
+  );
+
+  -- Signal stability during read bus cycle
+  property addr_stable_until_read_resp is (
+    always (rden_i -> next (stable(addr_i) until_ (ack_o or err_o)))
+  );
+
+
+  CONSTRAIN : if ASSUMES generate
+
+    assume no_read_write_during_reset;
+    assume no_read_write_until_write_resp;
+    assume no_read_write_until_read_resp;
+    assume onehot0_read_write;
+    assume addr_stable_until_write_resp;
+    assume data_stable_until_write_resp;
+    assume addr_stable_until_read_resp;
+
+  else generate
+
+    assert no_read_write_during_reset;
+    assert no_read_write_until_write_resp;
+    assert no_read_write_until_read_resp;
+    assert onehot0_read_write;
+    assert addr_stable_until_write_resp;
+    assert data_stable_until_write_resp;
+    assert addr_stable_until_read_resp;
+
+  end generate;
+
+end architecture;

--- a/core/neorv32_gpio/Makefile
+++ b/core/neorv32_gpio/Makefile
@@ -1,0 +1,13 @@
+RTL_DIR := ../../neorv32/rtl/core
+
+DUT := neorv32_gpio
+
+.PHONY: cover bmc prove all clean
+
+all: cover bmc prove
+
+cover bmc prove: ${RTL_DIR}/${DUT}.vhd symbiyosys.sby
+	sby --yosys "yosys -m ghdl" -f -d work/${DUT}-$@ symbiyosys.sby $@
+
+clean:
+	rm -rf work

--- a/core/neorv32_gpio/neorv32_gpio_vu.vhd
+++ b/core/neorv32_gpio/neorv32_gpio_vu.vhd
@@ -1,0 +1,146 @@
+-- #################################################################################################
+-- # << NEORV32 - GPIO PSL vunit  file >>                                                          #
+-- # ********************************************************************************************* #
+-- # BSD 3-Clause License                                                                          #
+-- #                                                                                               #
+-- # Copyright (c) 2023, Torsten Meissner. All rights reserved.                                    #
+-- #                                                                                               #
+-- # Redistribution and use in source and binary forms, with or without modification, are          #
+-- # permitted provided that the following conditions are met:                                     #
+-- #                                                                                               #
+-- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+-- #    conditions and the following disclaimer.                                                   #
+-- #                                                                                               #
+-- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+-- #    conditions and the following disclaimer in the documentation and/or other materials        #
+-- #    provided with the distribution.                                                            #
+-- #                                                                                               #
+-- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+-- #    endorse or promote products derived from this software without specific prior written      #
+-- #    permission.                                                                                #
+-- #                                                                                               #
+-- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+-- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+-- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+-- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+-- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+-- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+-- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+-- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+-- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+-- # ********************************************************************************************* #
+-- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- #################################################################################################
+
+
+vunit neorv32_gpio_vu (neorv32_gpio(neorv32_gpio_rtl)) {
+
+  signal gpio_sel_vu : std_logic;
+  signal addr_vu     : std_logic_vector(addr_i'range);
+
+  -- GPIO address space is selected
+  gpio_sel_vu <= '1' when unsigned(addr_i) >= unsigned(gpio_base_c) and
+                          unsigned(addr_i) <= (unsigned(gpio_base_c) + gpio_size_c - 1) else
+                 '0';
+
+  -- dword aligned address
+  addr_vu <= addr_i(addr_i'left downto 2) & "00";
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk_i);
+
+
+  -- Initial reset of 3 cycles
+  restrict {not rstn_i[*3]; rstn_i[+]}[*1];
+
+
+  -- Instantiate bus protocol tester in assume mode
+  bus_protocol : entity work.neorv32_bus_protocol
+  generic map (ASSUMES => true)
+  port map (clk_i, rstn_i, addr_i, rden_i, wren_i, data_i, data_o, ack_o , err_o);
+
+  -- @TODO: Refine address restriction
+  assume always wren_i or rden_i -> addr_i(addr_i'left downto 8) = x"FFFFFF";
+
+
+  -- Async reset of GPIO outs
+  process (all) is
+  begin
+    if (not rstn_i) then
+      GPIO_RESET : assert gpio_o = 64x"0";
+    end if;
+  end process;
+
+  -- Never write gpio outs without write enable
+  GPIO_STABLE :  assert always (
+    not wren_i -> next stable(gpio_o)
+  );
+
+  -- Never write lower gpio outs without gpio out low address
+  NO_LO_WRITE : assert always (
+    addr_vu /= gpio_out_lo_addr_c -> next stable (gpio_o(31 downto 0))
+  );
+
+  -- Never write upper gpio outs without gpio out high address
+  NO_HI_WRITE : assert always (
+    addr /= gpio_out_hi_addr_c -> next stable (gpio_o(63 downto 32))
+  );
+
+  -- Always ack or err response in next cycle
+  REQ_RESP : assert always (
+    (wren_i or rden_i) and gpio_sel_vu -> next (ack_o or err_o)
+  );
+
+  -- Never ack & err at same cycle
+  RESP_ONEHOT0 : assert always (
+    not (ack_o and err_o)
+  ) abort not rstn_i;
+
+  -- Responses active one cycle only
+  RESP_ONE_CYCLE : assert always (
+    ack_o or err_o -> next not ack_o and not err_o
+  );
+
+  -- Always ack response if write / read at valid addresses
+  ACK_RESP : assert always (
+    (wren_i and (addr_vu = gpio_out_lo_addr_c or addr_vu = gpio_out_hi_addr_c)) or (rden_i and gpio_sel_vu) ->
+    next ack_o
+  );
+
+  -- Always err response if write at invalid addresses
+  ERR_RESP : assert always (
+    (wren_i and gpio_sel_vu and addr_vu /= gpio_out_lo_addr_c and addr_vu /= gpio_out_hi_addr_c) ->
+    next err_o
+  );
+
+  -- Always write lower gpios at next cycle if wren and gpio out low address
+  WRITE_OUT_LO : assert always (
+    wren_i and addr_vu = gpio_out_lo_addr_c -> next gpio_o(31 downto 0) = prev(data_i)
+  );
+
+  -- Always write upper gpios at next cycle if wren and gpio out high address
+  WRITE_OUT_HI : assert always (
+    wren_i and addr_vu = gpio_out_hi_addr_c -> next gpio_o(63 downto 32) = prev(data_i)
+  );
+
+  -- Always set data out to state of gpio inputs 31:0 two cycles before if read at gpio in low address
+  READ_IN_LO : assert always (
+    rden_i and addr_vu = gpio_in_lo_addr_c -> next data_o = prev(gpio_i(31 downto 0), 2)
+  );
+
+  -- Always set data out to state of gpio inputs 63:32 two cycles before if read at gpio in high address
+  READ_IN_HI : assert always (
+    rden_i and addr_vu = gpio_in_hi_addr_c -> next data_o = prev(gpio_i(63 downto 32), 2)
+  );
+
+  -- Always set data out to state of gpio outputs 31:0 one cycle before if read at gpio out low address
+  READ_OUT_LO : assert always (
+    rden_i and addr_vu = gpio_out_lo_addr_c -> next data_o = prev(gpio_o(31 downto 0), 1)
+  );
+
+  -- Always set data out to state of gpio outputs 63:32 one cycle before if read at gpio out high address
+  READ_OUT_HI : assert always (
+    rden_i and addr_vu = gpio_out_hi_addr_c -> next data_o = prev(gpio_o(63 downto 32), 1)
+  );
+
+}

--- a/core/neorv32_gpio/symbiyosys.sby
+++ b/core/neorv32_gpio/symbiyosys.sby
@@ -1,0 +1,25 @@
+[tasks]
+cover
+bmc
+prove
+
+[options]
+depth 20
+cover: mode cover
+bmc: mode bmc
+prove: mode prove
+
+[engines]
+cover: smtbmc z3
+bmc: abc bmc3
+prove: aiger suprove
+
+[script]
+ghdl --std=08 --work=neorv32 neorv32_package.vhd neorv32_gpio.vhd neorv32_bus_protocol.vhd neorv32_gpio_vu.vhd -e neorv32_gpio
+prep -auto-top
+
+[files]
+../../neorv32/rtl/core/neorv32_package.vhd
+../../neorv32/rtl/core/neorv32_gpio.vhd
+../lib/neorv32_bus_protocol.vhd
+neorv32_gpio_vu.vhd

--- a/core/test.sh
+++ b/core/test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+set -e
+
+MAKE=make
+
+cd $(dirname "$0")
+
+case "$1" in
+  bmc)
+    true
+  ;;
+  cover)
+    true
+  ;;
+  prove)
+    true
+  ;;
+  *)
+    echo "Unknown test suite '$1'"
+    exit 1
+  ;;
+esac
+
+run_task() {
+  echo "::group::Test $1"
+  cd "$1"
+  $MAKE "$2"
+  cd ../
+  echo '::endgroup::'
+}
+
+for item in neorv32_gpio; do
+  run_task "$item" "$1"
+done


### PR DESCRIPTION
Here we go again .... based on discussions in stnolting/neorv32#475.

I've added a simple GHA workflow. Triggering by changes in the neorv32 submodule is another thing. All I found with googling were (for me) cryptic stuff about customized runners which use so called tokens or work with SSH. But I don't have any clue of that devops things.